### PR TITLE
Fill preservation behind checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@ optimizer</a>).</p>
     <p>Options:</p>
     <p>
       <label><input id="flip-x" type="checkbox"> Flip on <var>x</var> axis</label><br/>
-      <label><input id="flip-y" type="checkbox"> Flip on <var>y</var> axis</label>
+      <label><input id="flip-y" type="checkbox"> Flip on <var>y</var> axis</label><br/>
+      <label><input id="preserve-fill" type="checkbox"> Try to preserve fill color<span class="limitation"> (works only with fill attributes & expects colors in form #FFF or #FFFFFF).</span></label>
     </p>
     <p>
       Translate (applies after flip):<br/>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,11 @@ optimizer</a>).</p>
     <p>
       <label><input id="flip-x" type="checkbox"> Flip on <var>x</var> axis</label><br/>
       <label><input id="flip-y" type="checkbox"> Flip on <var>y</var> axis</label><br/>
-      <label><input id="preserve-fill" type="checkbox"> Try to preserve fill color<span class="limitation"> (works only with fill attributes & expects colors in form #FFF or #FFFFFF).</span></label>
+      <label>
+        <input id="preserve-fill" type="checkbox"> Try to preserve fill color (note, it's often preferable to specify an icon's color at runtime)
+        <br/>
+        <span class="limitation">Works only with fill attributes & expects colors in form #FFF or #FFFFFF.</span>
+      </label>
     </p>
     <p>
       Translate (applies after flip):<br/>

--- a/main.css
+++ b/main.css
@@ -49,3 +49,16 @@ html {
 pre {
   -webkit-margin-start: 2em;
 }
+
+input+span {
+  display: none;
+}
+
+input:checked+span {
+  display: inherit;
+}
+
+.limitation {
+  color: grey;
+  font-style: italic;
+}

--- a/main.css
+++ b/main.css
@@ -50,12 +50,8 @@ pre {
   -webkit-margin-start: 2em;
 }
 
-input+span {
+input:not(:checked) ~ .limitation {
   display: none;
-}
-
-input:checked+span {
-  display: inherit;
 }
 
 .limitation {

--- a/main.js
+++ b/main.js
@@ -91,9 +91,8 @@ function GetPathColorCommandFromFill(element) {
     // Colors in form #FFF or #FFFFFF.
     const hexColorRegExp = /^#([0-9a-f]{3})$|^#([0-9a-f]{6})$/gi;
     const fillMatch = fill.match(hexColorRegExp);
-    if (fillMatch && fillMatch.length === 1) {
+    if (fillMatch && fillMatch.length === 1)
       return ParseFillStringToPathColor(fillMatch[0]);
-    }
   }
 
   return '';

--- a/main.js
+++ b/main.js
@@ -54,7 +54,7 @@ function RoundToHundredths(x) {
 
 // |fillString| is expected to be "#RRGGBB" or "#RGB"].
 function PathColorFromFill(fillString) {
-  if(fillString.length === 4) {
+  if (fillString.length === 4) {
     // Color in form of #RGB so let's turn that to #RRGGBB.
     fillString = `#${fillString[1]}${fillString[1]}${fillString[2]}${fillString[2]}${fillString[3]}${fillString[3]}`.toUpperCase();
   }
@@ -72,14 +72,15 @@ function HandleNode(svgNode, scaleX, scaleY, translateX, translateY, preserveFil
     var svgElement = svgNode.children[idx];
 
     if (preserveFill) {
-      output += "NEW_PATH,\n";
-
       const fill = svgElement.getAttribute('fill');
-      if(fill && fill !== 'none') {
+      if (fill && fill !== 'none') {
         // Colors in form #FFF or #FFFFFF.
         const hexColorRegExp = /^#([0-9a-f]{3})$|^#([0-9a-f]{6})$/gi;
         const fillMatch = fill.match(hexColorRegExp);
         if(fillMatch && fillMatch.length === 1) {
+          if (idx !== 0)
+            output += "NEW_PATH,\n";
+
           output += PathColorFromFill(fillMatch[0]);
         }
       }
@@ -93,7 +94,7 @@ function HandleNode(svgNode, scaleX, scaleY, translateX, translateY, preserveFil
           break;
         }
 
-        return HandleNode(svgElement, scaleX, scaleY, translateX, translateY);
+        return HandleNode(svgElement, scaleX, scaleY, translateX, translateY, preserveFill);
 
       // PATH ------------------------------------------------------------------
       case 'path':


### PR DESCRIPTION
PR brings functionality to preserve `fill` attributes from SVGs by converting the attribute to a corresponding `PATH_COLOR_ARGB` command. Fill preservation is gated behind the checkbox that looks like this:

![image](https://user-images.githubusercontent.com/44477279/57472007-4b1ad080-7241-11e9-82c5-8964b8908550.png)
-----------------
This code only works for colors in the form #FFF and #FFFFFF and only supports the fill attribute. With the checkbox checked, a new path is created for each SVG node so that they can be independently colored from the fill of that node.