### PR TITLE
Properly separate attributes of different things

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,6 +98,8 @@ function HandleNode(svgNode, scaleX, scaleY, translateX, translateY) {
         if (svgElement.getAttribute('fill') == 'none' && !isStrokePath)
           break;
 
+        output += "NEW_PATH,\n";
+
         var commands = [];
         var path = svgElement.getAttribute('d').replace(/,/g, ' ').trim();
         if (path.slice(-1).toLowerCase() !== 'z')
@@ -219,6 +221,8 @@ function HandleNode(svgNode, scaleX, scaleY, translateX, translateY) {
 
       // CIRCLE ----------------------------------------------------------------
       case 'circle':
+        output += "NEW_PATH,\n";
+
         var cx = parseFloat(svgElement.getAttribute('cx'));
         cx *= scaleX;
         cx += translateX;
@@ -231,6 +235,8 @@ function HandleNode(svgNode, scaleX, scaleY, translateX, translateY) {
 
       // RECT ------------------------------------------------------------------
       case 'rect':
+        output += "NEW_PATH,\n";
+
         var x = parseFloat(svgElement.getAttribute('x')) || 0;
         x *= scaleX;
         x += translateX;
@@ -251,6 +257,8 @@ function HandleNode(svgNode, scaleX, scaleY, translateX, translateY) {
 
       // OVAL ----------------------------------------------------------------
       case 'ellipse':
+          output += "NEW_PATH,\n";
+
           var cx = parseFloat(svgElement.attr('cx')) || 0;
           cx *= scaleX;
           cx += translateX;


### PR DESCRIPTION
Stroke width is affected by this bug fix, as in the examples linked
below. When color functionality is added, it will be affected too. For
the examples, I produced the *.png images by manually cropping
screenshots. So please disregard inconsistencies in size and position.
[https://drive.google.com/drive/folders/1yYnCVzH3ZSIHWzKp1p08rgDzUQ6tmfje?usp=sharing](https://drive.google.com/drive/folders/1yYnCVzH3ZSIHWzKp1p08rgDzUQ6tmfje?usp=sharing)