### PR TITLE
Improve error reporting

### DIFF
--- a/main.js
+++ b/main.js
@@ -83,7 +83,7 @@ function HandleNode(svgNode, scaleX, scaleY, translateX, translateY) {
       // g ---------------------------------------------------------------------
       case 'g':
         if (svgElement.getAttribute('transform'))
-          output += "<g> with a transform not handled\n";
+          throw new Error("<g> with a transform not handled");
         else
           output += HandleNode(svgElement, scaleX, scaleY, translateX, translateY);
 
@@ -295,7 +295,13 @@ function ConvertInput() {
   if (canvasSize != 48)
     output += 'CANVAS_DIMENSIONS, ' + canvasSize + ',\n';
 
-  output += HandleNode(svgNode, scaleX, scaleY, translateX, translateY);
+  try {
+    output += HandleNode(svgNode, scaleX, scaleY, translateX, translateY);
+  } catch (e) {
+    $('output-span').textContent = e.name + ": " + e.message;
+    return;
+  }
+
   // Truncate final comma and newline.
   $('output-span').textContent = output.slice(0, -2);
 }


### PR DESCRIPTION
BEFORE: If there is a group with a transform somewhere in the middle of
the input SVG, it yields the message "<g> with a transform not handled"
at the corresponding position in the vector icon output, where you might
not notice. If it is at the end, then the word handled becomes handle,
because of code intended to remove a comma from the end of the output.

AFTER: If there is a group with a transform in the input SVG, then
"Error: <g> with a transform not handled" is the whole output. Any
JavaScript error in HandleNode is reported in a similar fashion.