### PR TITLE
Convert all color hex codes to upper case

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,9 +77,11 @@ function RoundToHundredths(x) {
 
 // |fillString| is expected to be "#RRGGBB" or "#RGB".
 function ParseFillStringToPathColor(fillString) {
+  fillString = fillString.toUpperCase();
+
   if (fillString.length === 4) {
     // Color in form of #RGB so let's turn that to #RRGGBB.
-    fillString = `#${fillString[1]}${fillString[1]}${fillString[2]}${fillString[2]}${fillString[3]}${fillString[3]}`.toUpperCase();
+    fillString = `#${fillString[1]}${fillString[1]}${fillString[2]}${fillString[2]}${fillString[3]}${fillString[3]}`;
   }
 
   const r = fillString.substr(1,2);


### PR DESCRIPTION
BEFORE: Colors in the form #RGB are converted to upper case, but colors
in the form #RRGGBB are not.

AFTER: All color hex codes are converted to upper case.