### PR TITLE
Set nonzero fill rule explicitly for new paths

### DIFF
--- a/run_tests.js
+++ b/run_tests.js
@@ -19,6 +19,7 @@ testCases = [
   { name: 'implicit_lineto' },
   { name: 'implicit_r_lineto' },
   { name: 'repeat_r_vh_lineto' },
+  { name: 'fill_rule_evenodd' },
 ]
 
 function runTests() {

--- a/skiafy.js
+++ b/skiafy.js
@@ -139,7 +139,12 @@ function HandleNode(svgNode, scaleX, scaleY, translateX, translateY, preserveFil
         // of the form <path fill="none" d="M0 0h24v24H0z"/>, so we skip.
         if (svgElement.getAttribute('fill') == 'none')
           break;
-
+        // Default SVG fill rule is Nonzero, but in Skia it is evenodd.
+        // So explicitly set FILL_RULE_NONZERO for all new paths, unless
+        // it has configured evenodd fill rule.
+        if (svgElement.getAttribute('fill-rule') != 'evenodd') {
+          output += 'FILL_RULE_NONZERO,\n';
+        }
         var commands = [];
         var path = svgElement.getAttribute('d').replace(/,/g, ' ').trim();
         if (path.slice(-1).toLowerCase() !== 'z')

--- a/test_data.js
+++ b/test_data.js
@@ -102,7 +102,6 @@ svg:
 `,
 expected:
 `CANVAS_DIMENSIONS, 16,
-FILL_RULE_EVENODD,
 R_H_LINE_TO, 1,
 R_H_LINE_TO, 2,
 R_H_LINE_TO, 4,

--- a/test_data.js
+++ b/test_data.js
@@ -6,6 +6,7 @@ svg:
 `,
 expected:
 `CANVAS_DIMENSIONS, 24,
+FILL_RULE_NONZERO,
 MOVE_TO, 12, 3,
 LINE_TO, 4, 9,
 R_V_LINE_TO, 12,
@@ -33,6 +34,7 @@ svg:
 expected:
 `CANVAS_DIMENSIONS, 24,
 PATH_COLOR_ARGB, 0xFF, 0xAA, 0xBB, 0xCC,
+FILL_RULE_NONZERO,
 MOVE_TO, 12, 3,
 LINE_TO, 4, 9,
 R_V_LINE_TO, 12,
@@ -59,6 +61,7 @@ svg:
 `,
 expected:
 `CANVAS_DIMENSIONS, 16,
+FILL_RULE_NONZERO,
 MOVE_TO, 1, 2,
 LINE_TO, 3, 4,
 CLOSE`},
@@ -70,6 +73,7 @@ svg:
 `,
 expected:
 `CANVAS_DIMENSIONS, 16,
+FILL_RULE_NONZERO,
 R_MOVE_TO, 1, 2,
 R_LINE_TO, 4, 3,
 R_LINE_TO, 1, 1,
@@ -82,6 +86,23 @@ svg:
 `,
 expected:
 `CANVAS_DIMENSIONS, 16,
+FILL_RULE_NONZERO,
+R_H_LINE_TO, 1,
+R_H_LINE_TO, 2,
+R_H_LINE_TO, 4,
+V_LINE_TO, 3,
+V_LINE_TO, 1,
+V_LINE_TO, 1,
+CLOSE`},
+
+'fill_rule_evenodd': {
+svg:
+`
+<svg xmlns="http://www.w3.org/2000/svg" width="16"><path fill-rule="evenodd" d="h1 2 4V3 1 1Z"/></svg>
+`,
+expected:
+`CANVAS_DIMENSIONS, 16,
+FILL_RULE_EVENODD,
 R_H_LINE_TO, 1,
 R_H_LINE_TO, 2,
 R_H_LINE_TO, 4,


### PR DESCRIPTION
See [crbug.com/330601413](http://crbug.com/330601413) for the context.

The default SVG fill rule is Nonzero, but at Skia side it has been evenodd. To bridge this gap, a new command was added to Skia to clarify nonzero fill type. This is the Skiafy side change, in which all new paths get explicitly configured nonzero, unless it has fill-rule=evenodd in its svg attribute.